### PR TITLE
Fix Fedora 36 image architecture

### DIFF
--- a/distros.json
+++ b/distros.json
@@ -14,7 +14,7 @@
     "32": "https://kojipkgs.fedoraproject.org/packages/Fedora-Cloud-Base/32/20210302.0/images/Fedora-Cloud-Base-32-20210302.0.x86_64.raw.xz",
     "33": "https://kojipkgs.fedoraproject.org/packages/Fedora-Cloud-Base/33/20201219.0/images/Fedora-Cloud-Base-33-20201219.0.x86_64.raw.xz",
     "35": "https://kojipkgs.fedoraproject.org/packages/Fedora-Cloud-Base/35/20220921.0/images/Fedora-Cloud-Base-35-20220921.0.x86_64.raw.xz",
-    "36": "https://kojipkgs.fedoraproject.org/packages/Fedora-Cloud-Base/36/20220921.0/images/Fedora-Cloud-Base-36-20220921.0.ppc64le.raw.xz",
+    "36": "https://kojipkgs.fedoraproject.org/packages/Fedora-Cloud-Base/36/20220924.0/images/Fedora-Cloud-Base-36-20220924.0.x86_64.raw.xz",
     "37": "https://kojipkgs.fedoraproject.org/packages/Fedora-Cloud-Base/37/20220921.n.0/images/Fedora-Cloud-Base-37-20220921.n.0.x86_64.raw.xz",
     "rawhide": "https://kojipkgs.fedoraproject.org/packages/Fedora-Cloud-Base/Rawhide/20220921.n.0/images/Fedora-Cloud-Base-Rawhide-20220921.n.0.x86_64.raw.xz"
   }


### PR DESCRIPTION
Fedora 36 image was pointing to a ppc64le image which is incompatible. Fixing to a x86_64 release.

PS: Sorry for the two PRs, I forget to add a proper name to the branch.