### PR TITLE
Enhanced Fedora packages install to be more Fedora-like

### DIFF
--- a/distro/fedora.py
+++ b/distro/fedora.py
@@ -37,27 +37,21 @@ def config(de_name: str, distro_version: str, root_partuuid: str, verbose_var: b
         case "gnome":
             print("Installing GNOME")
             chroot("dnf group install -y 'Fedora Workstation'")
-            chroot("systemctl set-default graphical.target")
         case "kde":
             print("Installing KDE")
             chroot("dnf group install -y 'KDE Plasma Workspaces'")
-            chroot("systemctl set-default graphical.target")
         case "mate":
             print("Installing MATE")
             chroot("dnf group install -y 'MATE Desktop'")
-            chroot("systemctl set-default graphical.target")
         case "xfce":
             print("Installing Xfce")
             chroot("dnf group install -y 'Xfce Desktop'")
-            chroot("systemctl set-default graphical.target")
         case "lxqt":
             print("Installing LXQt")
             chroot("dnf group install -y 'LXQt Desktop'")
-            chroot("systemctl set-default graphical.target")
         case "deepin":
             print("Installing deepin")
             chroot("dnf group install -y 'Deepin Desktop'")
-            chroot("systemctl set-default graphical.target")
         case "budgie":
             print("\033[91m" + "Budgie is not available for Fedora" + "\033[91m")
             exit(1)
@@ -66,6 +60,10 @@ def config(de_name: str, distro_version: str, root_partuuid: str, verbose_var: b
         case _:
             print("\033[91m" + "Invalid desktop environment!!! Remove all files and retry." + "\033[0m")
             exit(1)
+    
+    if not de_name == "cli":
+        print("Setting system to boot to gui")
+        chroot("systemctl set-default graphical.target")
             
     print("Fixing SELinux")
     # Create /.autorelabel to force SELinux to relabel all files

--- a/distro/fedora.py
+++ b/distro/fedora.py
@@ -27,7 +27,7 @@ def config(de_name: str, distro_version: str, root_partuuid: str, verbose_var: b
     match de_name:
         case "gnome":
             print("Installing gnome")
-            chroot("dnf group install -y 'Fedora Workstation'"
+            chroot("dnf group install -y 'Fedora Workstation'")
             chroot("systemctl set-default graphical.target")
         case "kde":
             print("Installing kde")

--- a/distro/fedora.py
+++ b/distro/fedora.py
@@ -23,11 +23,6 @@ def config(de_name: str, distro_version: str, root_partuuid: str, verbose_var: b
     chroot(f"dnf install https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-{distro_version}"
            f".noarch.rpm -y")
     
-    # TODO: Plymouth is never disabled, so why print it? Also, why disabling it?
-    #print("Disabling plymouth")  # may fail sometimes without error
-    # Disabling plymouth fails too
-    # chroot("plymouth-set-default-theme details -R &> /dev/null")
-    
     # TODO: Perhaps zram works with mainline?
     chroot("dnf remove zram-generator-defaults -y")  # remove zram as it fails for some reason
     chroot("systemctl disable systemd-zram-setup@zram0.service")  # disable zram service

--- a/distro/fedora.py
+++ b/distro/fedora.py
@@ -9,9 +9,11 @@ def config(de_name: str, distro_version: str, root_partuuid: str, verbose_var: b
     print("\033[96m" + "Configuring Fedora" + "\033[0m")
     print("Installing packages")
     chroot("dnf update -y")
-    chroot("dnf install linux-firmware -y")
-    chroot("dnf group install 'Minimal Install' -y")
-    chroot("dnf install NetworkManager-tui ncurses cloud-utils -y")
+    chroot("dnf group install -y 'Core'")
+    chroot("dnf group install -y 'Hardware Support'")
+    chroot("dnf group install -y 'Common NetworkManager Submodules'")
+    chroot("dnf install -y linux-firmware")
+    
     print("Add nonfree repos")
     chroot(f"dnf install https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-{distro_version}"
            f".noarch.rpm -y")
@@ -25,28 +27,28 @@ def config(de_name: str, distro_version: str, root_partuuid: str, verbose_var: b
     match de_name:
         case "gnome":
             print("Installing gnome")
-            # As gnome is not preinstalled on the cloud version, we need to install it "manually"
-            chroot(
-                "dnf install -y @base-x gnome-shell gnome-terminal nautilus firefox gnome-tweaks " +
-                "@development-tools gnome-terminal-nautilus xdg-user-dirs xdg-user-dirs-gtk gnome-calculator " +
-                "gnome-system-monitor gedit file-roller gdm gnome-initial-setup")
-            chroot("systemctl enable gdm.service")
+            chroot("dnf group install -y 'Fedora Workstation'"
+            chroot("systemctl set-default graphical.target")
         case "kde":
             print("Installing kde")
             chroot("dnf group install -y 'KDE Plasma Workspaces'")
-            chroot("systemctl enable sddm.service")
+            chroot("systemctl set-default graphical.target")
         case "mate":
             print("Installing mate")
             chroot("dnf group install -y 'MATE Desktop'")
+            chroot("systemctl set-default graphical.target")
         case "xfce":
             print("Installing xfce")
             chroot("dnf group install -y 'Xfce Desktop'")
+            chroot("systemctl set-default graphical.target")
         case "lxqt":
             print("Installing lxqt")
             chroot("dnf group install -y 'LXQt Desktop'")
+            chroot("systemctl set-default graphical.target")
         case "deepin":
             print("Installing deepin")
             chroot("dnf group install -y 'Deepin Desktop'")
+            chroot("systemctl set-default graphical.target")
         case "budgie":
             print("\033[91m" + "Budgie is not available for Fedora" + "\033[91m")
             exit(1)

--- a/distro/fedora.py
+++ b/distro/fedora.py
@@ -7,42 +7,51 @@ def config(de_name: str, distro_version: str, root_partuuid: str, verbose_var: b
     verbose = verbose_var
 
     print("\033[96m" + "Configuring Fedora" + "\033[0m")
-    print("Installing packages")
+    print("Updating packages")
     chroot("dnf update -y")
+    
+    print("Installing Core packages")
     chroot("dnf group install -y 'Core'")
+    
+    print("Installing Hardware Support packages")
     chroot("dnf group install -y 'Hardware Support'")
     chroot("dnf group install -y 'Common NetworkManager Submodules'")
     chroot("dnf install -y linux-firmware")
     
-    print("Add nonfree repos")
+    # TODO: Missing the free repos; add extras from a real Fedora install
+    print("Add RPMFusion nonfree repo")
     chroot(f"dnf install https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-{distro_version}"
            f".noarch.rpm -y")
-    print("Disabling plymouth")  # may fail sometimes without error
+    
+    # TODO: Plymouth is never disabled, so why print it? Also, why disabling it?
+    #print("Disabling plymouth")  # may fail sometimes without error
     # Disabling plymouth fails too
     # chroot("plymouth-set-default-theme details -R &> /dev/null")
+    
     # TODO: Perhaps zram works with mainline?
     chroot("dnf remove zram-generator-defaults -y")  # remove zram as it fails for some reason
     chroot("systemctl disable systemd-zram-setup@zram0.service")  # disable zram service
+    
     print("\033[96m" + "Downloading and installing DE, might take a while" + "\033[0m")
     match de_name:
         case "gnome":
-            print("Installing gnome")
+            print("Installing GNOME")
             chroot("dnf group install -y 'Fedora Workstation'")
             chroot("systemctl set-default graphical.target")
         case "kde":
-            print("Installing kde")
+            print("Installing KDE")
             chroot("dnf group install -y 'KDE Plasma Workspaces'")
             chroot("systemctl set-default graphical.target")
         case "mate":
-            print("Installing mate")
+            print("Installing MATE")
             chroot("dnf group install -y 'MATE Desktop'")
             chroot("systemctl set-default graphical.target")
         case "xfce":
-            print("Installing xfce")
+            print("Installing Xfce")
             chroot("dnf group install -y 'Xfce Desktop'")
             chroot("systemctl set-default graphical.target")
         case "lxqt":
-            print("Installing lxqt")
+            print("Installing LXQt")
             chroot("dnf group install -y 'LXQt Desktop'")
             chroot("systemctl set-default graphical.target")
         case "deepin":
@@ -53,10 +62,11 @@ def config(de_name: str, distro_version: str, root_partuuid: str, verbose_var: b
             print("\033[91m" + "Budgie is not available for Fedora" + "\033[91m")
             exit(1)
         case "cli":
-            print("Installing nothing")
+            print("No Desktop Environment will be installed")
         case _:
             print("\033[91m" + "Invalid desktop environment!!! Remove all files and retry." + "\033[0m")
             exit(1)
+            
     print("Fixing SELinux")
     # Create /.autorelabel to force SELinux to relabel all files
     with open("/mnt/eupnea/.autorelabel", "w") as f:


### PR DESCRIPTION
Changed package installation to be more Fedora-like.

Fixes a lot of missing packages adding "Core", "Hardware Support" and "Common NetworkManager Submodules" as default.

`linux-firmware` is kept but I'm not sure if it's necessary.

Changed the way to install GNOME. GNOME is the default DE on Fedora, so "Fedora Workstation" is the right group package to be installed.

Correct the way to load the Graphical Boot within a Fedora system with `graphical.target`.

Added more description during the "Core" packages phase, fixed some capitalization, made little changes to better express intent, added some TODOs.
